### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://vidzheyr.visualstudio.com/f6bb3cc9-4a89-4b37-a5ae-8812572a5330/d1de733e-4d5b-4c9c-ae82-9b7762d0a056/_apis/work/boardbadge/160eb71b-a9aa-4df6-bac8-673325a5329a)](https://vidzheyr.visualstudio.com/f6bb3cc9-4a89-4b37-a5ae-8812572a5330/_boards/board/t/d1de733e-4d5b-4c9c-ae82-9b7762d0a056/Microsoft.RequirementCategory)
 # Microsoft IIS 10 CIS Benchmark verification and remediation PowerShell scripts 
 
 This is an attempt to develop verification and remediation scripts for the [CIS IIS Security Benchmark](https://www.cisecurity.org/benchmark/microsoft_iis/) audit and remediation recommendations using PowerShell cmdlets from the WebAdministration module (and from the new IISAdministration module only if needed) . 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#199](https://vidzheyr.visualstudio.com/f6bb3cc9-4a89-4b37-a5ae-8812572a5330/_workitems/edit/199). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.